### PR TITLE
Accept # and . at the beginning of describe

### DIFF
--- a/src/minitest/spec.cr
+++ b/src/minitest/spec.cr
@@ -47,6 +47,7 @@ module Minitest
     macro describe(name, &block)
       {%
         class_name = name.id.stringify.strip
+          .gsub(/^(?:#|\.)/, "")
           .gsub(/[^0-9a-zA-Z:]+/, "_")
           .split("_").map { |s| [s[0...1].upcase, s[1..-1]].join("") }.join("")
           .split("::").map { |s| [s[0...1].upcase, s[1..-1]].join("") }.join("::")

--- a/test/spec_test.cr
+++ b/test/spec_test.cr
@@ -39,6 +39,18 @@ describe Minitest::Spec do
     end
   end
 
+  describe ".class_method describe" do
+    it "accepts" do
+      assert true
+    end
+  end
+
+  describe "#instance_method describe" do
+    it "accepts" do
+      assert true
+    end
+  end
+
   describe "let" do
     let(:foo) { Foo.new }
 


### PR DESCRIPTION
Class methods are usually described as `FooClass.class_method`, and instance methods are described as `FooClass#instance_method`. 
This patch enables us to write Specs of class methods and instance methods like below:

``` crystal
describe FooClass do
  describe ".class_method" do
    it "should do something" do
      # ...
    end
  end

  describe "#instance_method" do
    it "should do something" do
      # ...
    end
  end
end
```
