### PR TITLE
Run tests in single class instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # CHANGELOG
 
+## Unreleased
+
+Breaking Change:
+- Each test now runs in a single instance of the test class, so instance
+  variables don't leak from one test to another.
+
+  This change will have a breaking impact if you rely on instance variables to
+  cache or share data between tests. You'll may want to use class variables for
+  this purpose instead.
+
+Fixes:
+- Allows describes in specs to start with special chars like `.` or `#`.
+
 ## v0.2.0
 
 Feature:

--- a/src/minitest/runnable.cr
+++ b/src/minitest/runnable.cr
@@ -18,7 +18,7 @@ module Minitest
           @type.name
         end.id
       }}
-      klass.new(reporter).run_tests
+      klass.run_tests(reporter)
       nil
     end
 
@@ -27,7 +27,7 @@ module Minitest
     def initialize(@reporter)
     end
 
-    def run_tests
+    def self.run_tests(reporter)
     end
   end
 end

--- a/src/minitest/spec.cr
+++ b/src/minitest/spec.cr
@@ -2,30 +2,8 @@ require "./expectations"
 
 module Minitest
   class Spec < Test
-    def after_teardown
-      super()
-
-      if memoized = @_memoized
-        memoized.clear
-      end
-    end
-
-    # NOTE: we can't use Reference as a generic (yet) so we can't just rely on a
-    #       Hash to memoize the let values and clear it on each teardown. We
-    #       thus keep a list of generated keys to force the regeneration of a
-    #       variable on each test.
     macro let(name, &block)
       def {{ name.id }}
-        #@_memoized ||= {} of String => Reference
-        #@_memoized[{{ name.id.stringify }}] ||= begin; {{ yield }}; end
-
-        %memoized = @_memoized ||= [] of String
-
-        unless %memoized.includes?({{ name.id.stringify }})
-          %memoized << {{ name.id.stringify }}
-          @{{ name.id }} = nil
-        end
-
         @{{ name.id }} ||= begin; {{ yield }}; end
       end
     end

--- a/src/minitest/test.cr
+++ b/src/minitest/test.cr
@@ -25,16 +25,14 @@ module Minitest
     include LifecycleHooks
     include Assertions
 
-    macro def run_tests : Nil
-      {{
-        @type.methods
-          .map(&.name.stringify)
-          .select(&.starts_with?("test_"))
-          .shuffle
-          .map { |m| "run_one(#{m}) { #{m.id} }" }
-          .join("\n")
-          .id
-      }}
+    macro def self.run_tests(reporter) : Nil
+      {% names = @type.methods.map(&.name.stringify).select(&.starts_with?("test_")) %}
+
+      {% for name in names.shuffle %}
+        %test = new(reporter)
+        %test.run_one({{ name }}) { %test.{{ name.id }} }
+      {% end %}
+
       nil
     end
 

--- a/test/test_test.cr
+++ b/test/test_test.cr
@@ -1,0 +1,18 @@
+class Minitest::TestTest < Minitest::Test
+  # NOTE: we verify that tests are run in their own instance of the test suite,
+  #       so instance variables aren't stepping on each other.
+
+  def test_one
+    assert_equal :a, a
+    @a = :b
+  end
+
+  def test_two
+    assert_equal :a, a
+    @a = :c
+  end
+
+  def a
+    @a ||= :a
+  end
+end


### PR DESCRIPTION
> With ruby minitest, each test within a test file is run on a new instance of the test class. This prevents instance variables set in one test leaking into another test.

closes #6 
