### PR TITLE
Fix syntax error for >= Crystal 0.14

### DIFF
--- a/src/minitest/assertions.cr
+++ b/src/minitest/assertions.cr
@@ -4,7 +4,7 @@ class Exception
   getter :file, :line
 
   # NOTE: hack to report the source location that raised
-  def initialize(@message = nil : String?, @cause = nil : Exception?, @file = __FILE__, @line = __LINE__)
+  def initialize(@message : String? = nil, @cause : Exception? = nil, @file = __FILE__, @line = __LINE__)
     @backtrace = caller
     @callstack = CallStack.new
   end
@@ -250,7 +250,7 @@ module Minitest
     end
 
 
-    def assert_raises(message = nil : String, file = __FILE__, line = __LINE__)
+    def assert_raises(message : String = nil, file = __FILE__, line = __LINE__)
       begin
         yield
       rescue ex


### PR DESCRIPTION
After this commit compiling minitest.cr with Crystal 0.14.x works again.

Before this commit this error occurred.

```
Syntax error in ./src/minitest/assertions.cr:7: the syntax for an
argument with a default value V and type T is `arg : T = V`

  def initialize(@message = nil : String?, @cause = nil : Exception?,
@file = __FILE__, @line = __LINE__)
```
