### PR TITLE
minor syntactic fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ end
 
 Specs follow the same
 [design rationale](https://github.com/seattlerb/minitest/blob/master/design_rationale.rb)
-than the original Minitest: `describe` generates classes that inherit from
+as the original Minitest: `describe` generates classes that inherit from
 Minitest::Spec, and `it` generates test methods.
 
 ```crystal


### PR DESCRIPTION
(What follows is an observation that is hoped to be helpful, though it may not be an iron-clad rule, since English is a hodgepodge of many languages, and therefore not very consistent.  Also, it's just an off-the-cuff observation, rather than one I read in a grammar book that has been tested by generations of grammarians.  Nonetheless...)  "than" is used for contrasts, like 

> a Crystal app takes less CPU power _than_ a Ruby app

or 

> Ruby is cooler _than_ Java

etc., but "as" goes in phrases following the words "the same", and often in other phrases where similarity is expressed.  For instance, 

> Crystal syntax is as easy to learn _as_ Ruby syntax, but the executables run much faster _than_ Ruby scripts.
