### PR TITLE
Add --seed for reproducible test runs (and --chaos)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,5 +3,5 @@ CRYSTAL ?= `which crystal`
 .PHONY: test
 
 test:
-	$(CRYSTAL) run test/*_test.cr -- --parallel 4 --verbose
+	$(CRYSTAL) run test/*_test.cr -- --chaos --parallel 4 --verbose
 

--- a/src/minitest.cr
+++ b/src/minitest.cr
@@ -110,8 +110,7 @@ module Minitest
     process_args(args) if args
     puts options
 
-    Random::DEFAULT.new_seed(options.seed.to_u64)
-
+    random = Random::PCG32.new(options.seed.to_u64)
     channel = Channel::Buffered(Array(Runnable::Data) | Runnable::Data | Nil).new
     completed = Channel(Nil).new
 
@@ -144,14 +143,14 @@ module Minitest
       Runnable.runnables.each do |suite|
         tests += suite.collect_tests
       end
-      tests.shuffle!
+      tests.shuffle!(random)
       tests.each { |test| channel.send(test) }
     else
       # shufle each suite, then shuffle tests for each suite:
-      Runnable.runnables.shuffle!
+      Runnable.runnables.shuffle!(random)
       Runnable.runnables.each do |suite|
         tests = suite.collect_tests
-        tests.shuffle!
+        tests.shuffle!(random)
         tests.each { |test| channel.send(test) }
       end
     end

--- a/src/runnable.cr
+++ b/src/runnable.cr
@@ -7,26 +7,24 @@ module Minitest
     end
 
     alias Data = {Test.class, String, Proc(Test, Nil)}
-    @@tests = [] of Data
-
-    def self.tests
-      @@tests
-    end
 
     # Builds, at compile time, an Array with the test class, the test method
     # name, and a proc to call that method. The Array will then be shuffled at
     # runtime.
-    def self.collect_tests
+    def self.collect_tests : Array(Runnable::Data)
+      tests = [] of Runnable::Data
+
       {% begin %}
         {% for name in @type.methods.map(&.name).select(&.starts_with?("test_")) %}
           %proc = ->(test : Test) {
             test.as({{ @type }}).{{ name }}
             nil
           }
-          Runnable.tests << { {{ @type }}, {{ name.stringify }}, %proc }
+          tests << { {{ @type }}, {{ name.stringify }}, %proc }
         {% end %}
       {% end %}
-      nil
+
+      tests
     end
 
     getter reporter : AbstractReporter

--- a/src/test.cr
+++ b/src/test.cr
@@ -25,24 +25,6 @@ module Minitest
     include LifecycleHooks
     include Assertions
 
-    # Builds, at compile time, an Array with the test method name (String) and a
-    # proc to call that method. The Array will then be shuffled at runtime.
-    def self.run_tests(reporter)
-      {% begin %}
-        tests = [] of {String, Proc({{ @type }}, Nil)}
-
-        {% for name in @type.methods.map(&.name).select(&.starts_with?("test_")) %}
-          %proc =->(test : {{ @type }}) { test.{{ name }}; nil }
-          tests << { {{ name.stringify }}, %proc }
-        {% end %}
-
-        tests.shuffle.each do |(name, proc)|
-          new(reporter).run_one(name, proc)
-        end
-      {% end %}
-      nil
-    end
-
     def run_one(name, proc)
       case pattern = reporter.options.pattern
       when Regex  then return unless name =~ pattern

--- a/src/test.cr
+++ b/src/test.cr
@@ -25,20 +25,25 @@ module Minitest
     include LifecycleHooks
     include Assertions
 
+    # Builds, at compile time, an Array with the test method name (String) and a
+    # proc to call that method. The Array will then be shuffled at runtime.
     def self.run_tests(reporter)
       {% begin %}
-        {% names = @type.methods.map(&.name).select(&.starts_with?("test_")) %}
+        tests = [] of {String, Proc({{ @type }}, Nil)}
 
-        {% for name in names.shuffle %}
-          %test = new(reporter)
-          %test.run_one({{ name.stringify }}) { %test.{{ name }} }
+        {% for name in @type.methods.map(&.name).select(&.starts_with?("test_")) %}
+          %proc =->(test : {{ @type }}) { test.{{ name }}; nil }
+          tests << { {{ name.stringify }}, %proc }
         {% end %}
-      {% end %}
 
+        tests.shuffle.each do |(name, proc)|
+          new(reporter).run_one(name, proc)
+        end
+      {% end %}
       nil
     end
 
-    def run_one(name)
+    def run_one(name, proc)
       case pattern = reporter.options.pattern
       when Regex  then return unless name =~ pattern
       when String then return unless name == pattern
@@ -51,8 +56,7 @@ module Minitest
           before_setup
           setup
           after_setup
-
-          yield
+          proc.call(self)
         end
 
         capture_exception(result) { before_teardown }


### PR DESCRIPTION
Tests are now shuffled at runtime after initializing the PRNG with a seed (specified or random) so tests can be run in a reproducible order for debug purposes.

Bonus: tests are now shuffled globally, and workers will pick tests one by one, instead of picking a test suite and running all its tests.

closes #14 