### PR TITLE
Allow to "make" on MacOS. Error below:

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CRYSTAL_BIN ?= = `which crystal`
+CRYSTAL_BIN ?= `which crystal`
 
 .PHONY: test
 


### PR DESCRIPTION
```
➜  minitest.cr git:(master) make
= `which crystal` run test/*_test.cr -- --parallel 4 --verbose
/bin/sh: =: command not found
make: *** [test] Error 127
```