### PR TITLE
Change documentation to use crystal run.

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,20 +84,20 @@ expect(meme.will_it_blend?).wont_match(/^no/i)
 Eventually run the tests:
 
 ```
-$ crystal test/meme_test.cr spec/meme_spec.cr -- --verbose
+$ crystal run test/meme_test.cr spec/meme_spec.cr -- --verbose
 ```
 
 You may filter your tests using an exact test name, or a regexp:
 
 ```
-$ crystal test/meme_test.cr -- -n test_that_kitty_can_eat
-$ crystal test/meme_test.cr -- -n /will/
+$ crystal run test/meme_test.cr -- -n test_that_kitty_can_eat
+$ crystal run test/meme_test.cr -- -n /will/
 ```
 
 When using Minitest::Spec with assertions or the `expect` syntax, you can avoid to taint Object with all the `#must_` and `#wont_` expectations:
 
 ```
-$ crystal -Dmt_no_expectations spec/meme_spec.cr
+$ crystal run -Dmt_no_expectations spec/meme_spec.cr
 ```
 
 ## License


### PR DESCRIPTION
Hi, guys o/

I'd like to change the main documentation to show only usage of `crystal run file1_test.cr file2_test.cr`, because calling only `crystal file1_test.cr file2_test.cr` seems do run only the first file.

Example:

```
%  git clone https://gist.github.com/ccb4fd84ffd7e77e4f06f578ce192971.git
Cloning into 'ccb4fd84ffd7e77e4f06f578ce192971'...
remote: Counting objects: 25, done.   
remote: Compressing objects: 100% (15/15), done. 
remote: Total 25 (delta 5), reused 25 (delta 5), pack-reused 0
Unpacking objects: 100% (25/25), done.
%  cd ccb4fd84ffd7e77e4f06f578ce192971
%  crystal deps install                                
Using compiled compiler at .build/crystal
Fetching https://github.com/ysbaddaden/minitest.cr.git
Installing minitest (0.3.5)              
%  crystal test1_test.cr test2_test.cr  # Only run the first file
Using compiled compiler at .build/crystal
.                                                      

Finished in 00:00:00.0015572, 642.17826868738769 runs/s
                                          
1 tests, 0 failures, 0 errors, 0 skips   
%  crystal test1_test.cr && crystal test2_test.cr
Using compiled compiler at .build/crystal
.                                                      

Finished in 00:00:00.0015097, 662.38325495131483 runs/s
 
1 tests, 0 failures, 0 errors, 0 skips
Using compiled compiler at .build/crystal
.

Finished in 00:00:00.0012568, 795.67154678548695 runs/s

1 tests, 0 failures, 0 errors, 0 skips
%  crystal run test1_test.cr test2_test.cr # This way all test run 
Using compiled compiler at .build/crystal
..

Finished in 00:00:00.0016399, 609.79328007805361 runs/s

2 tests, 0 failures, 0 errors, 0 skips
%
```

And, of course, there is the same issue while filtering:

```
%  crystal test1_test.cr test2_test.cr -- -n /test_assert_false/ 
Using compiled compiler at .build/crystal


Finished in 00:00:00.0014618, 684.08811054863861 runs/s

0 tests, 0 failures, 0 errors, 0 skips
%  crystal run test1_test.cr test2_test.cr -- -n /test_assert_false/
Using compiled compiler at .build/crystal
.

Finished in 00:00:00.0014448, 692.13732004429676 runs/s

1 tests, 0 failures, 0 errors, 0 skips
```

:) 