### PR TITLE
Fix incorrect parameter order passed to assert_equal

### DIFF
--- a/src/expectations.cr
+++ b/src/expectations.cr
@@ -95,7 +95,7 @@ module Minitest
     end
 
     def wont_equal(expected, message = nil, file = __FILE__, line = __LINE__)
-      refute_equal(@target, expected, message, file, line)
+      refute_equal(expected, @target, message, file, line)
     end
 
     def must_be_close_to(expected, delta = 0.001, message = nil, file = __FILE__, line = __LINE__)

--- a/src/expectations.cr
+++ b/src/expectations.cr
@@ -91,7 +91,7 @@ module Minitest
     end
 
     def must_equal(expected, message = nil, file = __FILE__, line = __LINE__)
-      assert_equal(@target, expected, message, file, line)
+      assert_equal(expected, @target, message, file, line)
     end
 
     def wont_equal(expected, message = nil, file = __FILE__, line = __LINE__)


### PR DESCRIPTION
This fixes the bug that I mentioned in https://github.com/ysbaddaden/minitest.cr/issues/18

