### PR TITLE
Extends list of matchers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /.crystal
+/.idea

--- a/src/expectations.cr
+++ b/src/expectations.cr
@@ -74,6 +74,22 @@ module Minitest
     def wont_be_same_as(expected, message = nil, file = __FILE__, line = __LINE__)
       Expectation.new(self).wont_be_same_as(expected, message, file, line)
     end
+
+    def must_match_array(array, message = nil, file = __FILE__, line = __LINE__)
+      Expectation.new(self).must_match_array(array, message, file, line)
+    end
+
+    def wont_match_array(array, message = nil, file = __FILE__, line = __LINE__)
+      Expectation.new(self).wont_match_array(array, message, file, line)
+    end
+
+    def must_be_truthy(message = nil, file = __FILE__, line = __LINE__)
+      Expectation.new(self).must_be_truthy(message, file, line)
+    end
+
+    def must_be_falsey(message = nil, file = __FILE__, line = __LINE__)
+      Expectation.new(self).must_be_falsey(message, file, line)
+    end
   end
 
   class Expectation(T)
@@ -152,6 +168,46 @@ module Minitest
 
     def wont_be_same_as(expected, message = nil, file = __FILE__, line = __LINE__)
       refute_same(@target, expected, message, file, line)
+    end
+
+    def must_change(message = nil, file = __FILE__, line = __LINE__, **opts)
+      if opts.empty?
+        assert_changes(@target, message, file, line) { yield }
+      elsif opts.has_key?(:by)
+        assert_changes(@target, opts[:by]?, message, file, line) { yield }
+      elsif opts.has_key?(:from) && opts.has_key?(:from)
+        assert_changes(@target, opts[:from]?, opts[:to]?, message, file, line) { yield }
+      else
+        raise "Unknown change matcher arguments (#{opts.inspect})."
+      end
+    end
+
+    def must_change_at_least(by, message = nil, file = __FILE__, line = __LINE__, &block)
+      assert_changes_at_least(@target, by, message, file, line) { yield }
+    end
+
+    def must_change_at_most(by, message = nil, file = __FILE__, line = __LINE__, &block)
+      assert_changes_at_most(@target, by, message, file, line) { yield }
+    end
+
+    def wont_change(message = nil, file = __FILE__, line = __LINE__, &block)
+      refute_changes(@target, message, file, line) { yield }
+    end
+
+    def must_match_array(array, message = nil, file = __FILE__, line = __LINE__)
+      assert_matches_array(array, @target, message, file, line)
+    end
+
+    def wont_match_array(array, message = nil, file = __FILE__, line = __LINE__)
+      refute_matches_array(array, @target, message, file, line)
+    end
+
+    def must_be_truthy(message = nil, file = __FILE__, line = __LINE__)
+      assert_truthy(@target, message, file, line)
+    end
+
+    def must_be_falsey(message = nil, file = __FILE__, line = __LINE__)
+      assert_falsey(@target, message, file, line)
     end
   end
 end

--- a/src/runnable.cr
+++ b/src/runnable.cr
@@ -18,5 +18,8 @@ module Minitest
 
     def self.run_tests(reporter)
     end
+
+    def self.after_all
+    end
   end
 end

--- a/src/spec.cr
+++ b/src/spec.cr
@@ -8,6 +8,13 @@ module Minitest
       end
     end
 
+    macro let(name, klass, &block)
+      @{{name.id}} : {{klass}}?
+      def {{ name.id }}
+        @{{ name.id }} ||= begin; {{ yield }}; end
+      end
+    end
+
     macro before(&block)
       def setup
         super()
@@ -45,8 +52,18 @@ module Minitest
       end
     end
 
+    macro xit(name = "anonymous", &block)
+    end
+
+    macro describe(name = "anonymous", &block)
+    end
+
     def expect(value)
       Expectation.new(value)
+    end
+
+    def expect(&block)
+      Expectation.new(block)
     end
   end
 end
@@ -55,10 +72,10 @@ end
 macro describe(name, &block)
   {%
     class_name = name.id.stringify
-      .gsub(/[^0-9a-zA-Z:]+/, "_")
-      .gsub(/^_|_$/, "")
-      .split("_").map { |s| [s[0...1].upcase, s[1..-1]].join("") }.join("")
-      .split("::").map { |s| [s[0...1].upcase, s[1..-1]].join("") }.join("::")
+                        .gsub(/[^0-9a-zA-Z:]+/, "_")
+                        .gsub(/^_|_$/, "")
+                        .split("_").map { |s| [s[0...1].upcase, s[1..-1]].join("") }.join("")
+                                                                                    .split("::").map { |s| [s[0...1].upcase, s[1..-1]].join("") }.join("::")
   %}
   class {{ class_name.id }}Spec < Minitest::Spec
     def self.name

--- a/src/test.cr
+++ b/src/test.cr
@@ -35,6 +35,8 @@ module Minitest
         {% end %}
       {% end %}
 
+      after_all
+
       nil
     end
 

--- a/test/expectations_test.cr
+++ b/test/expectations_test.cr
@@ -91,4 +91,70 @@ class ExpectationsTest < Minitest::Spec
     1.wont_be_nil
     assert_raises(Minitest::Assertion) { nil.wont_be_nil }
   end
+
+  it "must_change" do
+    i = 0
+    expect { i += 1 }.must_change { i }
+    assert_raises(Minitest::Assertion) { expect { i += 2 - 2 }.must_change { i } }
+  end
+
+  it "must_change with by" do
+    i = 0
+    expect { i += 1 }.must_change(by: 1) { i }
+    assert_raises(Minitest::Assertion) { expect { i += 2 }.must_change(by: 1) { i } }
+  end
+
+  it "must_change_at_least" do
+    i = 0
+    expect { i += 3 }.must_change_at_least(1) { i }
+    expect { i += 1 }.must_change_at_least(1) { i }
+    assert_raises(Minitest::Assertion) { expect { i += 2 }.must_change_at_least(3) { i } }
+  end
+
+  it "must_change_at_most" do
+    i = 0
+    expect { i += 1 }.must_change_at_most(1) { i }
+    expect { i += 2 }.must_change_at_most(3) { i }
+    assert_raises(Minitest::Assertion) { expect { i += 2 }.must_change_at_most(1) { i } }
+  end
+
+  it "must_change with from and to args" do
+    i = 0
+    expect { i += 1 }.must_change(from: 0, to: 1) { i }
+    assert_raises(Minitest::Assertion) { expect { i += 2 }.must_change(from: 0, to: 1) { i } }
+  end
+
+  it "wont_change" do
+    i = 0
+    expect { i += 0 }.wont_change { i }
+    assert_raises(Minitest::Assertion) { expect { i += 2 }.wont_change { i } }
+  end
+
+  it "must_match_array" do
+    [1, 2, 3].must_match_array([3, 2, 1])
+    assert_raises(Minitest::Assertion) { [1, 2, 3].must_match_array([3, 2]) }
+  end
+
+  it "wont_match_array" do
+    [1, 2, 3].wont_match_array([3, 2])
+    assert_raises(Minitest::Assertion) { [1, 2, 3].wont_match_array([3, 2, 1]) }
+  end
+
+  it "must_be_truthy" do
+    true.must_be_truthy
+    1.must_be_truthy
+    "".must_be_truthy
+    ([] of String)..must_be_truthy
+    ({} of String => String).must_be_truthy
+    Foo.new.must_be_truthy
+    assert_raises(Minitest::Assertion) { false.must_be_truthy }
+    assert_raises(Minitest::Assertion) { nil.must_be_truthy }
+  end
+
+  it "must_be_falsey" do
+    false.must_be_falsey
+    nil.must_be_falsey
+    assert_raises(Minitest::Assertion) { true.must_be_falsey }
+    assert_raises(Minitest::Assertion) { Foo.new.must_be_falsey }
+  end
 end

--- a/test/spec_test.cr
+++ b/test/spec_test.cr
@@ -10,6 +10,7 @@ describe Minitest::Spec do
   end
 
   let(:data) { "data value" }
+  let(:random, Float64) { rand }
 
   it "accepts a block" do
     assert true
@@ -19,7 +20,7 @@ describe Minitest::Spec do
 
   it("reports the original failure location") do
     ex = assert_raises(Minitest::Assertion) { assert false }
-    assert_equal("test/spec_test.cr:21", ex.location)
+    assert_equal("test/spec_test.cr:22", ex.location)
   end
 
   it "calls an instance method" do
@@ -36,6 +37,7 @@ describe Minitest::Spec do
     it "accesses let methods" do
       assert_equal "data value", data
       assert_equal "more data value", more
+      random
     end
   end
 
@@ -61,5 +63,9 @@ describe Minitest::Spec do
       expect(1).must_equal(1)
       expect(Foo.new).wont_be_same_as(Foo.new)
     end
+  end
+
+  xit "ignores nested code" do
+    1 / 0
   end
 end


### PR DESCRIPTION
Added list of new matchers:
- change
- match_array
- be_truthy
- be_falsey
- instance_of

Also added "xit" to disable test case from compilation. Added let with class definition (sometimes we can get error of impossibility of class prediction from compiler). Added `after_all` callback method for `Runnable`.