### PR TITLE
Remove macro def

### DIFF
--- a/src/runnable.cr
+++ b/src/runnable.cr
@@ -1,12 +1,12 @@
 module Minitest
   class Runnable
-    macro def self.runnables : Array(Runnable.class)
+    def self.runnables : Array(Runnable.class)
       {% begin %}
         [self, {{ @type.all_subclasses.join(", ").id }}]
       {% end %}
     end
 
-    macro def self.run(reporter)
+    def self.run(reporter)
       {{ @type }}.run_tests(reporter)
       nil
     end

--- a/src/test.cr
+++ b/src/test.cr
@@ -25,7 +25,7 @@ module Minitest
     include LifecycleHooks
     include Assertions
 
-    macro def self.run_tests(reporter)
+    def self.run_tests(reporter)
       {% begin %}
         {% names = @type.methods.map(&.name).select(&.starts_with?("test_")) %}
 


### PR DESCRIPTION
It has been finally removed from the compiler in https://github.com/crystal-lang/crystal/pull/5040.