### PR TITLE
Prefer `Tempfile#delete` over the dead alias

### DIFF
--- a/src/assertions.cr
+++ b/src/assertions.cr
@@ -80,8 +80,8 @@ module Minitest
           .strip
       end
     ensure
-      if a; a.unlink; end
-      if b; b.unlink; end
+      if a; a.delete; end
+      if b; b.delete; end
     end
 
     def assert(actual, message = nil, file = __FILE__, line = __LINE__)


### PR DESCRIPTION
Compiling current `master` on [Crystal nightly](https://hub.docker.com/r/crystallang/crystal/tags/) produces this error:

```
Error in test/assertions_test.cr:1: while requiring "../src/autorun"

require "../src/autorun"
^

in src/autorun.cr:9: instantiating 'Minitest:Module#run(Array(String))'

  exit_code = Minitest.run(ARGV)
                       ^~~

in src/minitest.cr:119: instantiating 'loop()'

        loop do
        ^~~~

in src/minitest.cr:119: instantiating 'loop()'

        loop do
        ^~~~

in src/minitest.cr:123: instantiating 'Array(Tuple(Minitest::Test:Class, String, Proc(Minitest::Test, Nil)))#each()'

            value.each do |test|
                  ^~~~

in /usr/share/crystal/src/indexable.cr:148: instantiating 'each_index()'

    each_index do |i|
    ^~~~~~~~~~

in /usr/share/crystal/src/indexable.cr:148: instantiating 'each_index()'

    each_index do |i|
    ^~~~~~~~~~

in src/minitest.cr:123: instantiating 'Array(Tuple(Minitest::Test:Class, String, Proc(Minitest::Test, Nil)))#each()'

            value.each do |test|
                  ^~~~

in src/minitest.cr:125: instantiating 'Minitest::Test+#run_one(String, Proc(Minitest::Test, Nil))'

              suite.new(reporter).run_one(name, proc)
                                  ^~~~~~~

in src/test.cr:36: instantiating 'Time:Class#measure()'

      result.time = Time.measure do
                         ^~~~~~~

in src/test.cr:36: instantiating 'Time:Class#measure()'

      result.time = Time.measure do
                         ^~~~~~~

in src/test.cr:37: instantiating 'capture_exception(Minitest::Result)'

        capture_exception(result) do
        ^~~~~~~~~~~~~~~~~

in src/test.cr:37: instantiating 'capture_exception(Minitest::Result)'

        capture_exception(result) do
        ^~~~~~~~~~~~~~~~~

in src/test.cr:39: instantiating 'setup()'

          setup
          ^~~~~

in test/lifecycle_hooks_test.cr:13: instantiating 'assert_equal(String, (String | Nil))'

    assert_equal "before_setup", state_was
    ^~~~~~~~~~~~

in src/assertions.cr:111: instantiating 'assert_equal(String, (String | Nil), Nil, String, Int32)'

    def assert_equal(expected, actual, message = nil, file = __FILE__, line = __LINE__)
    ^

in src/assertions.cr:114: instantiating 'diff(String, (String | Nil))'

          result = diff(expected, actual)
                   ^~~~

in src/assertions.cr:83: undefined method 'unlink' for Tempfile

      if a; a.unlink; end
              ^~~~~~

Rerun with --error-trace to show a complete error trace.
Makefile:6: recipe for target 'test' failed
make: *** [test] Error 1
```

Refs https://github.com/crystal-lang/crystal/pull/6036