### PR TITLE
Add focus

### DIFF
--- a/src/focus.cr
+++ b/src/focus.cr
@@ -1,0 +1,31 @@
+module Minitest
+  class Runnable
+    FOCUSES = Hash(String, Array(String)).new
+
+    macro focus(definition)
+      %focuses = FOCUSES[{{@type}}.name] ||= [] of String
+      %focuses << {{definition.name.stringify}}
+      {{definition}}
+    end
+
+    macro it(name = "anonymous", focus = false, &block)
+      {% if focus %}focus{% end %} def test_{{ name.strip.gsub(/[^0-9a-zA-Z:]+/, "_").id }}
+        ret = {{ yield }}
+      end
+    end
+  end
+
+  class Test < Runnable
+    def should_run?(name)
+      focused_test?(name) && super(name)
+    end
+
+    def focused_test?(name)
+      {% begin %}
+      if focuses = FOCUSES[{{@type}}.name]?
+        focuses.empty? || focuses.includes?(name)
+      end
+      {% end %}
+    end
+  end
+end

--- a/src/focus.cr
+++ b/src/focus.cr
@@ -21,11 +21,17 @@ module Minitest
     end
 
     def focused_test?(name)
-      {% begin %}
-      if focuses = FOCUSES[{{@type}}.name]?
-        focuses.empty? || focuses.includes?(name)
+      if FOCUSES.empty?
+        true
+      else
+        {% begin %}
+          if focuses = FOCUSES[{{@type}}.name]?
+            focuses.includes?(name)
+          else
+            false
+          end
+        {% end %}
       end
-      {% end %}
     end
   end
 end

--- a/src/runnable.cr
+++ b/src/runnable.cr
@@ -31,5 +31,17 @@ module Minitest
 
     def initialize(@reporter)
     end
+
+    def should_run?(name) : Bool
+      matches_pattern?(name)
+    end
+
+    def matches_pattern?(name)
+      case pattern = reporter.options.pattern
+      when Regex  then false unless name =~ pattern
+      when String then false unless name == pattern
+      end
+      true
+    end
   end
 end

--- a/src/test.cr
+++ b/src/test.cr
@@ -26,10 +26,7 @@ module Minitest
     include Assertions
 
     def run_one(name, proc)
-      case pattern = reporter.options.pattern
-      when Regex  then return unless name =~ pattern
-      when String then return unless name == pattern
-      end
+      return unless should_run?(name)
 
       result = Result.new(self.class.name, name)
 


### PR DESCRIPTION
Sometimes we want to focus on specific tests, but can't easily filter them with `-n`. The `focus` macro enables to mark a test method to be run, which will filter out other test methods for the test run. Specs can use the `focus: true` argument to achieve the same.

For example:

```crystal
require "minitest/autorun"
require "minitest/focus"

class MyTest < Minitest::Test
  focus def test_something
  end
end

describe "MyTest" do
  it "something", focus: true do
  end
end
```

closes #30