### PR TITLE
Fix responds to assertions

### DIFF
--- a/src/assertions.cr
+++ b/src/assertions.cr
@@ -265,13 +265,13 @@ module Minitest
 
 
     macro assert_responds_to(obj, method, message = nil, file = __FILE__, line = __LINE__)
-      %msg = -> { message || "Expected #{ {{ obj }}.inspect} (#{ {{ obj }}.class.name}) to respond to ##{ {{ method }} }" }
-      assert {{ obj }}.responds_to?(:{{ method.id }}), %msg, file, line
+      %msg = -> { {{ message }} || "Expected #{ {{ obj }}.inspect} (#{ {{ obj }}.class.name}) to respond to ##{ {{ method }} }" }
+      assert {{ obj }}.responds_to?(:{{ method.id }}), %msg, {{ file }}, {{ line }}
     end
 
     macro refute_responds_to(obj, method, message = nil, file = __FILE__, line = __LINE__)
-      %msg = -> { message || "Expected #{ {{ obj }}.inspect} (#{ {{ obj }}.class.name}) to not respond to ##{ {{ method }} }" }
-      refute {{ obj }}.responds_to?(:{{ method.id }}), %msg, file, line
+      %msg = -> { {{ message }} || "Expected #{ {{ obj }}.inspect} (#{ {{ obj }}.class.name}) to not respond to ##{ {{ method }} }" }
+      refute {{ obj }}.responds_to?(:{{ method.id }}), %msg, {{ file }}, {{ line }}
     end
 
 

--- a/test/assertions_test.cr
+++ b/test/assertions_test.cr
@@ -165,6 +165,17 @@ class AssertionsTest < Minitest::Test
   end
 
 
+  def test_assert_responds_to
+    assert_responds_to Foo.new, :inspect
+    assert_raises(Minitest::Assertion) { assert_responds_to Foo.new, :foo }
+  end
+
+  def test_refute_responds_to
+    refute_responds_to Foo.new, :foo
+    assert_raises(Minitest::Assertion) { refute_responds_to Foo.new, :inspect }
+  end
+
+
   def test_assert_raises
     ex = assert_raises { raise "error message" }
     assert_equal "error message", ex.message


### PR DESCRIPTION
Fixes #32 and adds missing unit tests for `assert_reponds_to`  and `refute_responds_to`.