### PR TITLE
Fix: support crystal interpreter + bugfixes + diff algorithm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,10 +2,16 @@ name: Continuous Integration
 
 on:
   push:
-    branches: [master]
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+    branches:
+      - "**"
 
   pull_request:
-    branches: [master]
+    branches:
+      - "**:**"
+
+  release:
 
   schedule:
     - cron: "0 6 * * 1"
@@ -17,8 +23,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: oprypin/install-crystal@v1
-      - run: shards install
+      - uses: crystal-lang/install-crystal@v1
       - run: make test
 
   test_mt:
@@ -27,6 +32,5 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: oprypin/install-crystal@v1
-      - run: shards install
+      - uses: crystal-lang/install-crystal@v1
       - run: make test CRFLAGS=-Dpreview_mt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # CHANGELOG
 
+## Unreleased
+
+Fixes:
+- Compatibility with Crystal interpreter.
+- Runnables aren't shuffled in non chaos mode.
+
+Features:
+- Add `message` helper to wrap custom messages for custom assertions on top of
+  existing assertions (missing feature from original Ruby Minitest).
+- Implements a diff algorithm to remove a dependency on `diff` external tools.
+
 ## v1.0.0
 
 Identical to v0.5.1. A mere v1 stable release of Minitest for Crystal v1.

--- a/src/diff.cr
+++ b/src/diff.cr
@@ -1,0 +1,171 @@
+# Original diff algorithm writen by TSUYUSATO Kitsune (MakeNowJust), distributed
+# under the MIT license.
+#
+# See <https://github.com/makenowjust/crystal-diff/blob/master/src/diff.cr>
+struct Minitest::Diff(T)
+  enum Type
+    DELETED
+    APPENDED
+    UNCHANGED
+
+    def reverse : self
+      case self
+      in DELETED then APPENDED
+      in APPENDED then DELETED
+      in UNCHANGED then UNCHANGED
+      end
+    end
+  end
+
+  record Delta,
+    type : Type,
+    a : Range(Int32, Int32),
+    b : Range(Int32, Int32) do
+
+    def append(other : self) : self
+      copy_with(
+        a: a.begin...other.a.end,
+        b: b.begin...other.b.end,
+      )
+    end
+  end
+
+  def self.line_diff(a : String, b : String)
+    new(a.split('\n'), b.split('\n'))
+  end
+
+  getter a : T
+  getter b : T
+  @m : Int32
+  @n : Int32
+  @swap : Bool
+
+  def initialize(a : T, b : T)
+    if @swap = (b.size < a.size)
+      @a, @m = b, b.size
+      @b, @n = a, a.size
+    else
+      @a, @m = a, a.size
+      @b, @n = b, b.size
+    end
+
+    @delta = @n - @m
+
+    @path = Array(Int32).new(@m + 1 + @n + 1, -1)
+    @points = [] of {Int32, Int32, Int32}
+    @patch = [] of {Int32, Int32}
+    @deltas = [] of Delta
+
+    p = calculate_edit_distance
+    generate_patch(p)
+    generate_deltas
+
+    # the algorithm places appends before deletes, but diffs usually show the
+    # opposite: the deleted (original) then the appended (that replaces the
+    # original)
+    swap_appends_and_deletes
+  end
+
+  def each(& : Delta ->) : Nil
+    @deltas.each { |delta| yield delta }
+  end
+
+  private def swap_appends_and_deletes
+    previous = nil
+
+    @deltas.each_with_index do |current, i|
+      if previous.try(&.appended?) && current.type.deleted?
+        @deltas.swap(i - 1, i)
+      end
+      previous = current.type
+    end
+  end
+
+  private def generate_deltas
+    x = y = x0 = y0 = 0
+
+    @patch.reverse_each do |(px, py)|
+      while x < px && py - px < y - x
+        x += 1
+      end
+      add_delta(:deleted, x0...x, y0...y) unless x0 == x
+      x0 = x
+
+      while y < py && py - px > y - x
+        y += 1
+      end
+      add_delta(:appended, x0...x, y0...y) unless y0 == y
+      y0 = y
+
+      while x < px && y < py && py - px == y - x
+        x += 1
+        y += 1
+      end
+      add_delta(:unchanged, x0...x, y0...y) unless x0 == x
+      x0, y0 = x, y
+    end
+  end
+
+  private def add_delta(type : Type, a, b)
+    delta =
+      if @swap
+        Delta.new(type.reverse, b, a)
+      else
+        Delta.new(type, a, b)
+      end
+
+    if (last = @deltas.last?) && delta.type == last.type
+      @deltas[-1] = last.append(delta)
+    else
+      @deltas << delta
+    end
+  end
+
+  private def calculate_edit_distance : Int32
+    fp = Array(Int32).new(@m + 1 + @n + 1) { -1 }
+    p = -1
+
+    loop do
+      p += 1
+
+      (-p).upto(@delta - 1) do |k|
+        fp[k] = snake(k, fp[k - 1] + 1, fp[k + 1])
+      end
+
+      (@delta + p).downto(@delta + 1) do |k|
+        fp[k] = snake(k, fp[k - 1] + 1, fp[k + 1])
+      end
+
+      fp[@delta] = snake(@delta, fp[@delta - 1] + 1, fp[@delta + 1])
+
+      break if fp[@delta] == @n
+    end
+
+    # edit distance is `@delta + 2 * p`
+    p
+  end
+
+  private def snake(k : Int32, y0 : Int32, y1 : Int32) : Int32
+    r = y0 > y1 ? @path[k - 1] : @path[k + 1]
+    y = {y0, y1}.max
+    x = y - k
+
+    while (x < @m) && (y < @n) && (@a[x] == @b[y])
+      x += 1
+      y += 1
+    end
+
+    @path[k] = @points.size
+    @points << {x, y, r}
+
+    y
+  end
+
+  private def generate_patch(p : Int32)
+    r = @path[@delta]
+    until r == -1
+      x, y, r = @points[r]
+      @patch << {x, y}
+    end
+  end
+end

--- a/src/minitest.cr
+++ b/src/minitest.cr
@@ -143,8 +143,7 @@ module Minitest
       tests.each { |test| channel.send(test) }
     else
       # shufle each suite, then shuffle tests for each suite:
-      Runnable.runnables.shuffle!(random)
-      Runnable.runnables.each do |suite|
+      Runnable.runnables.shuffle!(random).each do |suite|
         tests = suite.collect_tests
         tests.shuffle!(random)
         tests.each { |test| channel.send(test) }

--- a/test/assertions_test.cr
+++ b/test/assertions_test.cr
@@ -31,9 +31,63 @@ class AssertionsTest < Minitest::Test
     assert_equal "abcd", "abcd"
     assert_raises(Minitest::Assertion) { assert_equal 1, 2 }
 
-    ex = assert_raises(Minitest::Assertion) { assert_equal "a\nb\n", "a\nc\n" }
-    assert_equal "--- expected\n+++ actual\n@@ -1,3 +1,3 @@\n \"a\n-b\n+c\n \"", ex.message
+    ex = assert_raises(Minitest::Assertion) { assert_equal "this is correct", "this is wrong" }
+    assert_equal %(Expected "this is correct" but got "this is wrong"), ex.message
   end
+
+  {% unless flag?(:interpreted) %}
+    def test_assert_equal_diffs_long_strings
+      correct = <<-PLAIN
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+      tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
+      quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+      consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse
+      cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat
+      non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+      PLAIN
+
+      wrong = <<-PLAIN
+      Lorem pisum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+      tempor incididunt ut labore et dolore manga aliqua. Ut enim ad minim veniam,
+      quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+      consequat. Duis aute irure dolor ni reprehenderit in voluptate velit esse
+      cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat
+      non proident, sunt ni culpa qui officia deserunt mollit anim id tse laborum.
+      PLAIN
+
+      ex = assert_raises(Minitest::Assertion) { assert_equal correct, wrong }
+      assert_equal <<-PLAIN, ex.message
+      --- expected
+      +++ actual
+      @@ -1,6 +1,6 @@
+      -Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+      -tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
+      +Lorem pisum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+      +tempor incididunt ut labore et dolore manga aliqua. Ut enim ad minim veniam,
+       quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+      -consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse
+      +consequat. Duis aute irure dolor ni reprehenderit in voluptate velit esse
+       cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat
+      -non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+      +non proident, sunt ni culpa qui officia deserunt mollit anim id tse laborum.
+      PLAIN
+    end
+
+    def test_assert_equal_diffs_pretty_printed_objects
+      a = { code: 1, message: "some long message to force a line break in pretty inspect", status: "failed" }
+      b = { code: 3, message: "some long message to force a line break in pretty inspect", status: "failed" }
+      ex = assert_raises(Minitest::Assertion) { assert_equal a, b }
+      assert_equal <<-PLAIN, ex.message
+      --- expected
+      +++ actual
+      @@ -1,3 +1,3 @@
+      -{code: 1,
+      +{code: 3,
+        message: "some long message to force a line break in pretty inspect",
+        status: "failed"}
+      PLAIN
+    end
+  {% end %}
 
   def test_refute_equal
     refute_equal 1, 2

--- a/test/assertions_test.cr
+++ b/test/assertions_test.cr
@@ -318,12 +318,9 @@ class AssertionsTest < Minitest::Test
     assert_equal "broken", ex.message
   end
 
-  def test_skipped
-    skip "testing that this test is skipped"
-    raise "should never be raised"
+  def test_message
+    assert_equal "default", (message(nil) { "default" }).call
+    assert_equal "string\ndefault", (message("string") { "default" }).call
+    assert_equal "proc:string\ndefault", (message(-> { "proc:string" }) { "default" }).call
   end
-
-  # def test_flunked
-  #   flunk
-  # end
 end

--- a/test/assertions_test.cr
+++ b/test/assertions_test.cr
@@ -35,59 +35,55 @@ class AssertionsTest < Minitest::Test
     assert_equal %(Expected "this is correct" but got "this is wrong"), ex.message
   end
 
-  {% unless flag?(:interpreted) %}
-    def test_assert_equal_diffs_long_strings
-      correct = <<-PLAIN
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
-      tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
-      quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
-      consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse
-      cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat
-      non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
-      PLAIN
+  def test_assert_equal_diffs_long_strings
+    correct = <<-PLAIN
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+    tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
+    quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+    consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse
+    cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat
+    non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+    PLAIN
 
-      wrong = <<-PLAIN
-      Lorem pisum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
-      tempor incididunt ut labore et dolore manga aliqua. Ut enim ad minim veniam,
-      quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
-      consequat. Duis aute irure dolor ni reprehenderit in voluptate velit esse
-      cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat
-      non proident, sunt ni culpa qui officia deserunt mollit anim id tse laborum.
-      PLAIN
+    wrong = <<-PLAIN
+    Lorem pisum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+    tempor incididunt ut labore et dolore manga aliqua. Ut enim ad minim veniam,
+    quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+    consequat. Duis aute irure dolor ni reprehenderit in voluptate velit esse
+    cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat
+    non proident, sunt ni culpa qui officia deserunt mollit anim id tse laborum.
+    PLAIN
 
-      ex = assert_raises(Minitest::Assertion) { assert_equal correct, wrong }
-      assert_equal <<-PLAIN, ex.message
-      --- expected
-      +++ actual
-      @@ -1,6 +1,6 @@
-      -Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
-      -tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
-      +Lorem pisum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
-      +tempor incididunt ut labore et dolore manga aliqua. Ut enim ad minim veniam,
-       quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
-      -consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse
-      +consequat. Duis aute irure dolor ni reprehenderit in voluptate velit esse
-       cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat
-      -non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
-      +non proident, sunt ni culpa qui officia deserunt mollit anim id tse laborum.
-      PLAIN
-    end
+    ex = assert_raises(Minitest::Assertion) { assert_equal correct, wrong }
+    assert <<-PLAIN == ex.message
+    --- expected
+    +++ actual
+    -Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+    -tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
+    +Lorem pisum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+    +tempor incididunt ut labore et dolore manga aliqua. Ut enim ad minim veniam,
+     quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+    -consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse
+    +consequat. Duis aute irure dolor ni reprehenderit in voluptate velit esse
+     cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat
+    -non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+    +non proident, sunt ni culpa qui officia deserunt mollit anim id tse laborum.
+    PLAIN
+  end
 
-    def test_assert_equal_diffs_pretty_printed_objects
-      a = { code: 1, message: "some long message to force a line break in pretty inspect", status: "failed" }
-      b = { code: 3, message: "some long message to force a line break in pretty inspect", status: "failed" }
-      ex = assert_raises(Minitest::Assertion) { assert_equal a, b }
-      assert_equal <<-PLAIN, ex.message
-      --- expected
-      +++ actual
-      @@ -1,3 +1,3 @@
-      -{code: 1,
-      +{code: 3,
-        message: "some long message to force a line break in pretty inspect",
-        status: "failed"}
-      PLAIN
-    end
-  {% end %}
+  def test_assert_equal_diffs_pretty_printed_objects
+    a = { code: 1, message: "some long message to force a line break in pretty inspect", status: "failed" }
+    b = { code: 3, message: "some long message to force a line break in pretty inspect", status: "failed" }
+    ex = assert_raises(Minitest::Assertion) { assert_equal a, b }
+    assert <<-PLAIN == ex.message
+    --- expected
+    +++ actual
+    -{code: 1,
+    +{code: 3,
+      message: "some long message to force a line break in pretty inspect",
+      status: "failed"}
+    PLAIN
+  end
 
   def test_refute_equal
     refute_equal 1, 2


### PR DESCRIPTION
Minitest is now compatible with the Crystal interpreter! I can (almost) run the full minitest test suite (minus tests that rely on Process because of https://github.com/crystal-lang/crystal/issues/12241), with a significantly faster startup time! :partying_face: 

Introduces a `diff` algorithm based on [crystal-diff](https://github.com/makenowjust/crystal-diff) by @makenowjust that replaces calls to the external `diff` command line tool that probably only worked on Linux. This also makes diffs available in the Crystal interpreter as Minitest no longer has to use `Process` :tada: 

The PR also fixes a couple issues:

- introduces `message` to wrap custom messages, so there should be less problems when writing custom assertions with custom messages when mixing String and Proc(String) for example.
- tests weren't fully random (the tests were, but the runnables were not) :face_in_clouds: 

Please note that the printed messages may have changed, since we now print the custom and the default message (i.e. `"custom message\nExpected..."`), same for diffs that no longer print the `@@` line.