### PR TITLE
Fix: spec allows single colons (:) in describe and it macros

### DIFF
--- a/src/spec.cr
+++ b/src/spec.cr
@@ -25,10 +25,9 @@ module Minitest
     macro describe(name, &block)
       {%
         class_name = name.id.stringify
-          .gsub(/[^0-9a-zA-Z:]+/, "_")
-          .gsub(/^_|_$/, "")
-          .split("_").map { |s| [s[0...1].upcase, s[1..-1]].join("") }.join("")
-          .split("::").map { |s| [s[0...1].upcase, s[1..-1]].join("") }.join("::")
+          .split("::")
+          .map(&.gsub(/[^0-9a-zA-Z]+/, "_").gsub(/^_|_$/, "").capitalize)
+          .join("::")
       %}
       class {{ class_name.id }}Spec < {{ @type }}
         def self.name
@@ -40,7 +39,7 @@ module Minitest
     end
 
     macro it(name = "anonymous", &block)
-      def test_{{ name.strip.gsub(/[^0-9a-zA-Z:]+/, "_").id }}
+      def test_{{ name.strip.gsub(/[^0-9a-zA-Z]+/, "_").id }}
         {{ yield }}
       end
     end
@@ -55,10 +54,9 @@ end
 macro describe(name, &block)
   {%
     class_name = name.id.stringify
-      .gsub(/[^0-9a-zA-Z:]+/, "_")
-      .gsub(/^_|_$/, "")
-      .split("_").map { |s| [s[0...1].upcase, s[1..-1]].join("") }.join("")
-      .split("::").map { |s| [s[0...1].upcase, s[1..-1]].join("") }.join("::")
+      .split("::")
+      .map(&.gsub(/[^0-9a-zA-Z]+/, "_").gsub(/^_|_$/, "").capitalize)
+      .join("::")
   %}
   class {{ class_name.id }}Spec < Minitest::Spec
     def self.name

--- a/test/spec_test.cr
+++ b/test/spec_test.cr
@@ -43,6 +43,10 @@ describe Minitest::Spec do
   describe("ending with special chars #") {}
   it(". has leading and ending special chars .") {}
 
+  describe("has ::colons:") do
+    it("has ::colons:") {}
+  end
+
   describe "let" do
     let(:foo) { Foo.new }
 


### PR DESCRIPTION
Only double colons (::) should be accepted and only in describe macros, so we can `describe Minitest::Spec` for example, while it doesn't make sense for methods.

I also simplified the transformation a bit. The only difference is for describes of the form `describe "foo::bar:baz"` that are now transformed into `Foo::Bar_baz` when it used to be `Foo::BarBaz`. I don't think it will have any side effects? If we prefer the older form or not break the rationale, we can replace the `.capitalize` call for `.camelcase`.

closes #46