### PR TITLE
Spec: let with type declaration

### DIFF
--- a/src/spec.cr
+++ b/src/spec.cr
@@ -3,9 +3,21 @@ require "./expectations"
 module Minitest
   class Spec < Test
     macro let(name, &block)
-      def {{ name.id }}
-        @{{ name.id }} ||= begin; {{ yield }}; end
-      end
+      {% if name.is_a?(TypeDeclaration) %}
+        {% if name.value && block %}
+          {% raise "A let declaration MUST have a default value OR an initializer block but NOT both" %}
+        {% end %}
+
+        @{{name.var}} : {{name.type}} | Nil
+
+        def {{name.var}} : {{name.type}}
+          @{{name.var}} ||= {% if block %} {{yield}} {% else %} {{name.value}} {% end %}
+        end
+      {% else %}
+        def {{name.id}}
+          @{{name.id}} ||= {{yield}}
+        end
+      {% end %}
     end
 
     macro before(&block)

--- a/test/spec_test.cr
+++ b/test/spec_test.cr
@@ -49,6 +49,8 @@ describe Minitest::Spec do
 
   describe "let" do
     let(:foo) { Foo.new }
+    let(utc : Time) { Time.local }
+    let(local : Time = Time.local)
 
     it "memoizes the object for the duration of the test" do
       foo.bar = "baz"
@@ -57,6 +59,11 @@ describe Minitest::Spec do
 
     it "regenerates the object on each teardown" do
       assert_nil foo.bar
+    end
+
+    it "declares the object type" do
+      assert utc.is_a?(Time)
+      assert local.is_a?(Time)
     end
   end
 


### PR DESCRIPTION
The `let` macro now allows:

```crystal
describe "foo" do
  let(:name) { value }
  let(var : Type) { value }
  let(var : Type = value)
end
```

In all cases `value` will be lazily evaluated when called, then memoized for the duration of each test.